### PR TITLE
Is r oracle being envoked

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,9 +10,9 @@ Description: Provides a simple interface to easily connect to Oracle databases u
 License: CC0
 Encoding: UTF-8
 LazyData: true
+Depends: DBI
 Imports: 
     config,
-    DBI,
     odbc
 Suggests:
     ROracle

--- a/R/connections.R
+++ b/R/connections.R
@@ -48,6 +48,11 @@ create_connection <- function(db_name, config_path = NULL, driver = NULL){
 #'
 create_ROracle_connection <- function(db_name, config_path = NULL){
 
+  # Load ROracle library if already installed
+  if("ROracle" %in% rownames(installed.packages()) == TRUE){
+    library("ROracle")
+  }
+
   # get database credentials from config store
   db_cred <- read_db_creds(db_name, config_path, check_type = "stop")
   db_cred <- db_cred[[1]]

--- a/R/connections.R
+++ b/R/connections.R
@@ -14,12 +14,12 @@ create_connection <- function(db_name, config_path = NULL, driver = NULL){
 
   if(is.null(driver)){
     # first try with ROracle
-    con <- try(create_ROracle_connection(db_name, config_path), silent = TRUE)
-
-    # failing that, try with odbc
-    if(class(con) == "try-error"){
+    if((requireNamespace("ROracle", quietly = TRUE) == TRUE)){
+      con <- create_ROracle_connection(db_name, config_path)
+    }
+    else{
       message("No driver argument provided to create_connection:
-      Attempt to use ROracle failed, trying odbc instead")
+              ROracle not installed, trying odbc instead")
 
       con <- create_odbc_connection(db_name, config_path)
     }
@@ -48,10 +48,8 @@ create_connection <- function(db_name, config_path = NULL, driver = NULL){
 #'
 create_ROracle_connection <- function(db_name, config_path = NULL){
 
-  # Load ROracle library if already installed
-  if("ROracle" %in% rownames(installed.packages()) == TRUE){
-    library("ROracle")
-  }
+  # Load ROracle library
+  loadNamespace("ROracle")
 
   # get database credentials from config store
   db_cred <- read_db_creds(db_name, config_path, check_type = "stop")


### PR DESCRIPTION
Fixes #5 
Allows ROracle to be used as default. Prior to this fix, the function create_ROracle_connection was failing even if ROracle was installed. This should now be resolved.

We can now connect to DEVW if ROracle is installed, however you still can't connect to DEVW using odbc. I'll open this up as a new issue.

@odaniel1 I'm a bit worried that this fix might not work for users such as yourself where ROracle is installed, it's just misbehaving. Please could you check this fix still allows you to use odbc when connecting to PAINT_LIVE?