### PR TITLE
revised calls to loadNamespace/requireNamespace

### DIFF
--- a/R/connections.R
+++ b/R/connections.R
@@ -13,13 +13,16 @@
 create_connection <- function(db_name, config_path = NULL, driver = NULL){
 
   if(is.null(driver)){
-    # first try with ROracle
-    if((requireNamespace("ROracle", quietly = TRUE) == TRUE)){
+    # try to load ROracle namespace; if ROracle is available will return TRUE, else FALSE
+    roracle_available <- requireNamespace("ROracle", quietly = TRUE)
+
+    if(roracle_available == TRUE){
+      # connect using ROracle
       con <- create_ROracle_connection(db_name, config_path)
     }
     else{
-      message("No driver argument provided to create_connection:
-              ROracle not installed, trying odbc instead")
+      # connect using odbc
+      message("No driver argument provided to create_connection: ROracle not installed, trying odbc instead")
 
       con <- create_odbc_connection(db_name, config_path)
     }
@@ -28,6 +31,7 @@ create_connection <- function(db_name, config_path = NULL, driver = NULL){
       con <- create_odbc_connection(db_name, config_path)
   }
   else if(driver == "ROracle"){
+      loadNamespace("ROracle", quietly = TRUE)
       con <- create_ROracle_connection(db_name, config_path)
   }
 
@@ -47,9 +51,6 @@ create_connection <- function(db_name, config_path = NULL, driver = NULL){
 #' @return A dbconnect object.
 #'
 create_ROracle_connection <- function(db_name, config_path = NULL){
-
-  # Load ROracle library
-  loadNamespace("ROracle")
 
   # get database credentials from config store
   db_cred <- read_db_creds(db_name, config_path, check_type = "stop")


### PR DESCRIPTION
Hi Beatrice -

A minor change which will have a miniscule effect on performance, but is perhaps theoretically better as it avoids some duplication.

In the previous logic (assuming we're in the `driver = NULL` scenario, and ROracle is available) we would be loading the namespace twice: once when checking for availability with `requireNamespace("ROracle")` and a second time when calling `create_ROracle_connection`.

We still need a way of including the namespace when `driver = "ROracle" but this is now done before the call to `create_ROracle_connection`; I've chosen `loadNamespace` here as we want an error here.

If you're happy with this, we can merge this into your branch. I'd suggest you ask @Andrew-Billington to review (uninstall/re-install oracleConnectR) to check - that will give us an independent check that this has fixed the ROracle issue (as I can't test that on my machine).